### PR TITLE
Only switch the monitors' power based main map screen's power

### DIFF
--- a/Patches/ManualCameraRendererPatch.cs
+++ b/Patches/ManualCameraRendererPatch.cs
@@ -33,6 +33,11 @@ namespace GeneralImprovements.Patches
         [HarmonyPrefix]
         private static bool SwitchScreenOn(bool on, ManualCameraRenderer __instance, ref bool ___isScreenOn)
         {
+            if (__instance != StartOfRound.Instance.mapScreen)
+            {
+                return true;
+            }
+
             if (Plugin.SyncExtraMonitorsPower.Value)
             {
                 MonitorsHelper.ToggleExtraMonitorsPower(on);


### PR DESCRIPTION
This fixes an incompatibility with TwoRadarMaps due to `ManualCameraRenderer.SwitchScreenOn()` being called on the terminal's map renderer.