### PR TITLE
Replace WeatherTweaks reference with WeatherRegistry call

### DIFF
--- a/Patches/TerminalPatch.cs
+++ b/Patches/TerminalPatch.cs
@@ -236,7 +236,7 @@ namespace GeneralImprovements.Patches
                     // Now handle weather and optional price manually
                     for (int i = 0; i < allmoons.Count; i++)
                     {
-                        string weather = OtherModHelper.WeatherTweaksActive || allmoons[i].currentWeather == LevelWeatherType.None ? string.Empty : $"({allmoons[i].currentWeather}) ";
+                        string weather = OtherModHelper.WeatherRegistryActive ? $"({OtherModHelper.GetWeatherRegistryWeatherName(allmoons[i])})" : allmoons[i].currentWeather == LevelWeatherType.None ? string.Empty : $"({allmoons[i].currentWeather}) ";
                         var matchingMoonNode = routeNode.compatibleNouns.FirstOrDefault(n => allmoons[i].PlanetName.Contains(n.noun.word, StringComparison.OrdinalIgnoreCase));
                         if (matchingMoonNode != null)
                         {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -20,7 +20,7 @@ namespace GeneralImprovements
     [BepInDependency(OtherModHelper.CodeRebirthGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(OtherModHelper.MimicsGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(OtherModHelper.TwoRadarCamsGUID, BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInDependency(OtherModHelper.WeatherTweaksGUID, BepInDependency.DependencyFlags.SoftDependency)]
+    [BepInDependency(OtherModHelper.WeatherRegistryGUID, BepInDependency.DependencyFlags.SoftDependency)]
     public class Plugin : BaseUnityPlugin
     {
         public static ManualLogSource MLS { get; private set; }


### PR DESCRIPTION
This PR aims to replace current functionality targetting WeatherTweaks.

I wanted to bring to your attention an issue with GeneralImprovements disabling weathers from showing up in the terminal when WeatherTweaks is present, which [(as we've talked before)](https://discord.com/channels/1168655651455639582/1199836228858675330/1238553958386110595) is *not exactly how my mod works* and something that creates confusion for the users.

This will fix the following reported issues:
- https://discord.com/channels/1168655651455639582/1199836228858675330/1279956029311811654
- https://github.com/AndreyMrovol/LethalWeatherTweaks/issues/47

My commit does the following changes:
- remove `WeatherTweaks` reference in Terminal code preventing weathers from showing up completely
- add `WeatherRegistry` reference
- add a method for getting Registry's [`WeatherManager.GetCurrentWeatherName`](https://github.com/AndreyMrovol/LethalWeatherRegistry/blob/e9998501c1fac0d602725cf875d15e384e35417d/WeatherRegistry/WeatherManager.cs#L185-L194) which handles name overrides from other mods